### PR TITLE
Foreground process

### DIFF
--- a/misc/init.d-tcp_premailer
+++ b/misc/init.d-tcp_premailer
@@ -27,6 +27,11 @@ DAEMON=/home/polarfox/tcp_premailer/tcp_premailer.rb
 # pid file for the daemon
 PIDFILE=/tmp/tcp_premailer.pid
 
+# Read configuration variable file if it is present
+if [ -f /etc/default/tcp_premailer ] ; then
+        . /etc/default/tcp_premailer
+fi
+
 test -x $DAEMON || exit 5
 
 case $1 in

--- a/tcp_premailer.rb
+++ b/tcp_premailer.rb
@@ -132,6 +132,8 @@ case ARGV[0]
 		start
 	when 'stop'
 		stop
+	when 'foreground'
+	    run
 	else
 		exit
 end


### PR DESCRIPTION
Add the ability to run tcp_premailer in the foreground. Use case is to run tcp_premailer in a [Docker](https://www.docker.com) container

Also includes change to provide default config for the process